### PR TITLE
filterblock: drop None values from dataset

### DIFF
--- a/src/instructlab/sdg/filterblock.py
+++ b/src/instructlab/sdg/filterblock.py
@@ -58,6 +58,10 @@ class FilterByValueBlock(Block):
                 num_proc=self.num_procs,
             )
 
+        samples = samples.filter(
+            lambda x: x[self.column_name] is not None,
+            num_proc=self.num_procs,
+        )
 
         samples = samples.filter(
             lambda x: any(


### PR DESCRIPTION
We need to drop the None values added during the `_convert_dtype` step of the filterblock.